### PR TITLE
fix default redirect rule

### DIFF
--- a/src/administrator/components/com_base/controllers/service.php
+++ b/src/administrator/components/com_base/controllers/service.php
@@ -80,7 +80,7 @@ class ComBaseControllerService extends ComBaseControllerResource
 	protected function _actionPost($context)
 	{
 	    if ( $context->action == 'save' )
-	        $context->response->setRedirect('option=com_'.$this->getIdentifier()->package.'&view='.KInflector::pluralize($this->getIdentifier()->name));
+	        $context->response->setRedirect(JRoute::_('option=com_'.$this->getIdentifier()->package.'&view='.KInflector::pluralize($this->getIdentifier()->name)));
 	
 	    $data = $context->data;
 	


### PR DESCRIPTION
It seems recent changes touched LibBaseControllerResponse::setRedirect() so raw URLs must be passed through JRoute::_() before submitted to setRedirect().
