### PR TITLE
fix: autofollow installation

### DIFF
--- a/packages/Autofollow/src/plugins/user/autofollow.xml
+++ b/packages/Autofollow/src/plugins/user/autofollow.xml
@@ -12,6 +12,9 @@
     	to be automatically followed by the new registered members
     ]]>
     </description>
+    <files>
+       <filename plugin="autofollow">autofollow.php</filename>
+    </files>
     <params>
        <param name="actor_ids" type="textarea" rows="3" cols="40" default="" label="Actor IDs" description="Enter a comma seperated list of actor ids!" />
     </params>


### PR DESCRIPTION
without &lt;files&gt; anahita console utility is not able to install the
plugin

see http://www.getanahita.com/topics/124177-bug-autofollow-package-misses-files-directive-in-its-manifest-xml for reference
