### PR TITLE
fix: comment sanitazing

### DIFF
--- a/src/site/components/com_base/domains/entities/comment.php
+++ b/src/site/components/com_base/domains/entities/comment.php
@@ -73,7 +73,7 @@ class ComBaseDomainEntityComment extends ComBaseDomainEntityNode
      * 
      * @return void
      */
-    protected function _beforeEntityValidate(KCommandContext $context)
+    protected function _onEntityValidate(KCommandContext $context)
     {
         $this->parent->getRepository()->getBehavior('commentable')
             ->sanitizeComments(array($this));


### PR DESCRIPTION
fixes leftover from vlaidate event renaming which resulted in comments not being sanitaze in anahita 3.0
http://www.getanahita.com/todos/122024-comment-post-does-not-sanitize-for-invalid-html-tags
