### PR TITLE
fix: vote-unvote toggle

### DIFF
--- a/src/site/components/com_base/controllers/toolbars/default.php
+++ b/src/site/components/com_base/controllers/toolbars/default.php
@@ -117,8 +117,8 @@ class ComBaseControllerToolbarDefault extends ComBaseControllerToolbarAbstract
         $entity = $this->getController()->getItem();
         $voted  = $entity->votedUp(get_viewer());
                 
-        $btn_1_id   = uniqid();
-        $btn_2_id   = uniqid();
+        $btn_1_id   = uniqid('v');
+        $btn_2_id   = uniqid('u');
 
         $action_key     = '_action';
         


### PR DESCRIPTION
Fast server can generate subsequent uniqid() within same second
resulting in them being the same, patch fixes the issue, also makes
values of id attributes comply with HTML spec

see http://www.getanahita.com/topics/125053-bug-likeunlike-button-does-not-toggle-on-fast-server
