### PR TITLE
fix: urls when posted in wysiwyg editor

### DIFF
--- a/src/media/lib_anahita/js/editor/editor.js
+++ b/src/media/lib_anahita/js/editor/editor.js
@@ -145,6 +145,7 @@ var AnEditor = new Class({
 		var switchui = this.switchUI.bind(this);
 		var options  = {
 			  "apply_source_formatting" : false,
+			  "relative_urls" : false,
 			  "theme": "advanced",
 			  "mode": "exact",
 			  "elements": this.elementId,


### PR DESCRIPTION
TinyMCE by default replaces absolute URLs within same domain with
relative ones which breaks them on some occasions in anahita context,
the fix makes TinyMCE to use absolute URLs

see http://www.getanahita.com/topics/125441-bug-link-url-can-break-when-posted
