### PR TITLE
fix: empty values with validate-remote

### DIFF
--- a/src/media/lib_anahita/js/libs/Validation.js
+++ b/src/media/lib_anahita/js/libs/Validation.js
@@ -181,6 +181,11 @@ Class.refactor(Form.Validator.Inline, {
 			return this.status == 'error';
 		},
 		validate  : function() {
+			if ( Form.Validator.getValidator('IsEmpty').test(this.element) ) {
+				this.status = 'success';
+				return true;
+			}
+			
 			var self    = this;
 			var requestUrl  = this.props.url || this.element.form.get('action');
 			var value   = this.element.get('value');
@@ -266,10 +271,6 @@ Class.refactor(Form.Validator.Inline, {
 			return remoteValidator.getErrorMsg();
 		},
 		test 	: function(element, props) {
-			if ( Form.Validator.getValidator('IsEmpty').test(element) ) {
-				return true;
-			}
-			
 			var remoteValidator = element
 				.set('remoteValidator', props)
 				.get('remoteValidator');


### PR DESCRIPTION
fix validator so empty value sets RemoteValidator `status` to `success`
allowing other logic (namely onsubmit validation) to pick field
validation status properly

usecase:
form has 2 remote validators, field for 1st validator is left blank, field for 2nd validator has valid value; upon form submit, 2nd validator changes status to pending since it sends request asynchronously; when 2nd validator finishes, it checks if other remote validators registered for the form have success status.
before fix since check for empty value was performed outside validator, status could be null even if corresponding field considered valid which caused logic checking for success status of all remote validators return false;
after fix empty value updates validator status property thus resulting in proper recognizing of success status of all remote validators of the form.
