### PR TITLE
add: ability to hook into cli urilities

### DIFF
--- a/src/libraries/default/application/dispatcher.php
+++ b/src/libraries/default/application/dispatcher.php
@@ -202,6 +202,10 @@ class LibApplicationDispatcher extends LibBaseDispatcherApplication
         KRequest::url()->format = 'json';
         KRequest::url()->setQuery($_GET);
         
+        jimport('joomla.plugin.helper');
+        JPluginHelper::importPlugin('cli');
+        $this->_application->triggerEvent('onCli');
+        
         //if there's a file then just load the file and exit
         if ( !empty($file) ) 
         {


### PR DESCRIPTION
the patch introduces way for package developers to hook into CLI
utilities (e.g. cli utility sending email notifications) by creating a
newly introduced `cli` plugin type which can provide `onCli` event
handler

see http://www.getanahita.com/topics/123375-bug-unable-to-hook-into-code-executed-from-command-line

The patch cannot result in any conflicts because it will load new type of plugins, the only issue may be is that _JPluginHelper::importPlugin()_ can raise strict notifications when error_reporting includes E_STRICT, but this is system wide joomla legacy issue, doesn't relate to this patch in particular.
