### PR TITLE
fix: validate-remote

### DIFF
--- a/src/media/lib_anahita/js/libs/Validation.js
+++ b/src/media/lib_anahita/js/libs/Validation.js
@@ -99,10 +99,11 @@ Class.refactor(Form.Validator.Inline, {
 			if ( !this.retrieve('remoteValidators') ) {
 				var validators = new Array();
 				var element    = this;
+				var options = this.get('validator').options;
 				Object.merge(validators, {
 					isSuccess   : function() {
 						return this.length == 0 || this.every(function(validator){
-							return validator.isSuccess();
+							return options.ignoreHidden && ! validator.element.isVisible() || options.ignoreDisabled && validator.element.get('disabled') || validator.isSuccess();
 						});
 					},
 					validate  : function() {


### PR DESCRIPTION
When there are 2 or more remote validators in form, there can be a
situation when clicking form submit button doesn't submit the form, such
situation happens if one of validators is hidden or disabled, thus field
is considered valid, though RemoteValidator:isSuccess() would return
false anyway thus resulting in form not being submitted.

The patch makes sure that element visibility or disable status is
checked according to global form validator options ignoreHidden and
ignoreDisabled correspondingly when isSuccess status of all remote
validators is determined.
