### PR TITLE
prevent LibBaseDomainBehaviorPortraitable from generating the same

### DIFF
--- a/src/libraries/default/base/domain/behavior/portraitable.php
+++ b/src/libraries/default/base/domain/behavior/portraitable.php
@@ -265,7 +265,7 @@ class LibBaseDomainBehaviorPortraitable extends LibBaseDomainBehaviorStorable
 	    }
 	    	    
 	    $images          = $this->_mixer->resizePortraitImage($image);	    
-	    $this->_mixer->set('filename', md5(time().uniqid()).'.'.$mimetypes[$config->mimetype]);
+	    $this->_mixer->set('filename', md5(uniqid('', true)).'.'.$mimetypes[$config->mimetype]);
 	    $this->_mixer->set('mimetype', $config->mimetype);
 	    $sizes           = array();
 	    $files           = array();


### PR DESCRIPTION
filename for different attaches of the same user if it handles 2 files
within same second.

Fix is provided by @kulbakin
