### PR TITLE
Remove check for empty referrer

### DIFF
--- a/src/libraries/default/base/dispatcher/component.php
+++ b/src/libraries/default/base/dispatcher/component.php
@@ -183,12 +183,7 @@ class LibBaseDispatcherComponent extends LibBaseDispatcherAbstract implements KS
      */
     public function authenticateRequest(KCommandContext $context)
     {
-        $request = $context->request;
-        
-        //Check referrer
-        if(!$request->getReferrer()) {
-            throw new LibBaseControllerExceptionForbidden('Invalid Request Referrer');
-        }
+
     }
     
     /**


### PR DESCRIPTION
The referrer check breaks things when trying to access the JSON API via a PhoneGap app, so I'd like to suggest that it's removed.

Some users also prefer to keep their referrer's empty or even spoof it for privacy reasons. Given that it's so easy to spoof it really doesn't seem to serve much use to check it.