### PR TITLE
Fixes OAuthException already declared fatal error in 3.0.4

### DIFF
--- a/packages/Connect/src/site/components/com_connect/oauths/core.php
+++ b/packages/Connect/src/site/components/com_connect/oauths/core.php
@@ -3,8 +3,10 @@
 
 /* Generic exception class
  */
-class OAuthException extends Exception {
-  // pass
+if(! class_exists('OAuthException')) {
+  class OAuthException extends Exception {
+    // pass
+  }
 }
 
 class OAuthConsumer {


### PR DESCRIPTION
A fatal PHP error seems to occur in 3.0.4 because the `OAuthException` is re-declared for some reason. Can't quite figure out where that's taking place, so this is an easy fix.
