### PR TITLE
Photos title placeholder cleanup

### DIFF
--- a/packages/Photos/src/site/components/com_photos/views/photo/html/list.php
+++ b/packages/Photos/src/site/components/com_photos/views/photo/html/list.php
@@ -28,13 +28,17 @@
 	</div>
 	
 	<div class="entity-description-wrapper">
-		<h3 class="entity-title">
-		    <?php if( $photo->title ): ?>
-			<?= @escape( $photo->title ) ?>
-			<?php else : ?>
-			<span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>    
-			<?php endif; ?>    
-		</h3>
+		<?php if( $photo->title ): ?>
+			<h3 class="entity-title">
+				<a title="<?= @escape($photo->title) ?>" href="<?= @route($photo->getURL()) ?>">
+					<?= @escape( $photo->title ) ?>
+				</a>
+			</h3>
+		<?php elseif( $photo->authorize('edit') ) : ?>
+			<h3 class="entity-title">
+				<span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>
+			</h3>
+		<?php endif; ?>
 		
 		<div class="entity-description">
 			<?= @content(nl2br($photo->description), array('exclude'=>array('gist','video'))) ?>

--- a/packages/Photos/src/site/components/com_photos/views/photo/html/masonry.php
+++ b/packages/Photos/src/site/components/com_photos/views/photo/html/masonry.php
@@ -29,15 +29,17 @@
 	</div>
 	
 	<div class="entity-description-wrapper">
-    	<h4 class="entity-title">
-    		<?php if( $photo->title ): ?>
-            <a title="<?= @escape($photo->title) ?>" href="<?= @route($photo->getURL()) ?>">
-            <?= @escape($photo->title) ?>
-            </a>
-            <?php else : ?>
-            <span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>    
-            <?php endif; ?>  
-    	</h4>
+		<?php if( $photo->title ): ?>
+			<h4 class="entity-title">
+				<a title="<?= @escape($photo->title) ?>" href="<?= @route($photo->getURL()) ?>">
+					<?= @escape($photo->title) ?>
+				</a>
+			</h4>
+		<?php elseif( $photo->authorize('edit') ) : ?>
+			<h4 class="entity-title">
+				<span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>
+			</h4>
+		<?php endif; ?>
     		
     	<div class="entity-description">
     	<?= @helper('text.truncate', @content(nl2br($photo->description), array('exclude'=>array('gist','video'))), array('length'=>200, 'read_more'=>true, 'consider_html'=>true)); ?>

--- a/packages/Photos/src/site/components/com_photos/views/photo/html/photo.php
+++ b/packages/Photos/src/site/components/com_photos/views/photo/html/photo.php
@@ -14,13 +14,15 @@
 	</div>
 	
 	<div class="entity-description-wrapper">
-		<h3 class="entity-title">
-			<?php if( $photo->title ): ?>
-            <?= @escape( $photo->title ) ?>
-            <?php else : ?>
-            <span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>    
-            <?php endif; ?> 
-		</h3>
+		<?php if( $photo->title ): ?>
+			<h3 class="entity-title">
+				<?= @escape( $photo->title ) ?>
+			</h3>
+		<?php elseif( $photo->authorize('edit') ) : ?>
+			<h3 class="entity-title">
+				<span class="muted"><?= @text('LIB-AN-EDITABLE-PLACEHOLDER') ?></span>
+			</h3>
+		<?php endif; ?>
 		
 		<div class="entity-description">
 			<?= @content( nl2br($photo->description), array('exclude'=>array('gist','video'))) ?>


### PR DESCRIPTION
Revised to only display title placeholder if editable by viewer.  Also added link to photo title on list layout to be consistent with masonry layout.