### PR TITLE
InnoDB and UTF8 tables

### DIFF
--- a/src/administrator/components/com_anahita/schemas/migrations/14.php
+++ b/src/administrator/components/com_anahita/schemas/migrations/14.php
@@ -1,0 +1,38 @@
+<?php
+
+/**
+ * LICENSE: ##LICENSE##
+ *
+ * @package    Com_Anahita
+ * @subpackage Schema_Migration
+ */
+
+/**
+ * Schema Migration
+ *
+ * @package    Com_Anahita
+ * @subpackage Schema_Migration
+ */
+class ComAnahitaSchemaMigration14 extends ComMigratorMigrationVersion
+{
+   /**
+    * Called when migrating up
+    */
+    public function up()
+    {
+        //add your migration here
+        dbexec("ALTER TABLE #__users ENGINE=InnoDB");
+        dbexec("ALTER TABLE #__templates_menu ENGINE=InnoDB");
+        dbexec("ALTER TABLE #__plugins ENGINE=InnoDB");
+        dbexec("ALTER TABLE #__nodes ENGINE=InnoDB");
+        dbexec("ALTER TABLE #__components ENGINE=InnoDB");
+    }
+
+   /**
+    * Called when rolling back a migration
+    */
+    public function down()
+    {
+        //add your migration here
+    }
+}

--- a/vendor/joomla/installation/sql/schema.sql
+++ b/vendor/joomla/installation/sql/schema.sql
@@ -21,7 +21,7 @@ CREATE TABLE `#__edges` (
   KEY `node_b_id` (`node_b_id`),
   KEY `start_date` (`start_date`),
   KEY `end_date` (`end_date`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -147,7 +147,7 @@ CREATE TABLE `#__components` (
   `enabled` tinyint(4) NOT NULL DEFAULT '1',
   PRIMARY KEY (`id`),
   KEY `parent_option` (`parent`,`option`(32))
-) ENGINE=MyISAM;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -157,7 +157,7 @@ CREATE TABLE `#__migrator_versions` (
   `version` text NOT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `component` (`component`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -176,7 +176,7 @@ CREATE TABLE `#__plugins` (
   `params` text NOT NULL,
   PRIMARY KEY (`id`),
   KEY `idx_folder` (`published`,`client_id`,`access`,`folder`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -193,7 +193,7 @@ CREATE TABLE `#__session` (
   KEY `whosonline` (`guest`,`usertype`),
   KEY `userid` (`userid`),
   KEY `time` (`time`)
-) ENGINE=InnoDB;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -202,7 +202,7 @@ CREATE TABLE `#__templates_menu` (
   `menuid` int(11) NOT NULL DEFAULT '0',
   `client_id` tinyint(4) NOT NULL DEFAULT '0',
   PRIMARY KEY (`menuid`,`client_id`,`template`)
-) ENGINE=MyISAM;
+) ENGINE=InnoDB CHARACTER SET=utf8;
 
 -- --------------------------------------------------------
 
@@ -223,4 +223,4 @@ CREATE TABLE `#__users` (
   KEY `idx_name` (`name`),
   KEY `username` (`username`),
   KEY `email` (`email`)
-) ENGINE=MyISAM CHARACTER SET=utf8;
+) ENGINE=InnoDB CHARACTER SET=utf8;


### PR DESCRIPTION
made sure that the schema creates InnoDB and UTF-8 tables. migration 14 in Anahita converts all the remaining tables to InnoDB