### PR TITLE
fix for removing admins in groups

### DIFF
--- a/src/media/lib_anahita/js/anahita/actions/actor.js
+++ b/src/media/lib_anahita/js/anahita/actions/actor.js
@@ -82,7 +82,7 @@
 			return this;
 		}
 		
-		if ( action == 'addadmin' || action == 'removeadmin' ) {
+		if ( action == 'removeadmin' ) {
 			
 			$(this).attr('disabled', true);
 			
@@ -277,7 +277,7 @@
 	});
 	
 	//Remove Admin
-	$('body').on('click', '[data-action="removeadmin"]', function () {
+	$('body').on('click', '[data-action="removeadmin"]', function ( event ) {
 		
 		event.preventDefault();
 		$(this).anahitaActor('removeadmin');

--- a/src/media/lib_anahita/js/production/site.uncompressed.js
+++ b/src/media/lib_anahita/js/production/site.uncompressed.js
@@ -20621,7 +20621,7 @@ var sortable = $.widget("ui.sortable", $.ui.mouse, {
 			return this;
 		}
 		
-		if ( action == 'addadmin' || action == 'removeadmin' ) {
+		if ( action == 'removeadmin' ) {
 			
 			$(this).attr('disabled', true);
 			
@@ -20816,7 +20816,7 @@ var sortable = $.widget("ui.sortable", $.ui.mouse, {
 	});
 	
 	//Remove Admin
-	$('body').on('click', '[data-action="removeadmin"]', function () {
+	$('body').on('click', '[data-action="removeadmin"]', function ( events ) {
 		
 		event.preventDefault();
 		$(this).anahitaActor('removeadmin');


### PR DESCRIPTION
removing admins in groups wasn't working because the click event wasn't be passed to the handler.