### PR TITLE
allows entities to be modifiable by all actors

### DIFF
--- a/src/libraries/default/base/domain/behavior/modifiable.php
+++ b/src/libraries/default/base/domain/behavior/modifiable.php
@@ -67,8 +67,8 @@ class LibBaseDomainBehaviorModifiable extends AnDomainBehaviorAbstract
                 'updateTime' => array('column' => 'modified_on', 'default' => 'date'),
             ),
             'relationships' => array(
-                'author' => array('parent' => 'com:people.domain.entity.person', 'child_column' => 'created_by'),
-                'editor' => array('parent' => 'com:people.domain.entity.person', 'child_column' => 'modified_by'),
+                'author' => array('parent' => 'com:actors.domain.entity.actor', 'child_column' => 'created_by'),
+                'editor' => array('parent' => 'com:actors.domain.entity.actor', 'child_column' => 'modified_by'),
             ),
         ));
 


### PR DESCRIPTION
This appears to be the only bit of code that really prevents entities from being able to be posted by groups, other than a decent UI for it. It can still be done by carefully editing the database. Consider it a poor man's "Post as Group" functionality.