### PR TITLE
Remove action=add from signup form

### DIFF
--- a/src/components/com_people/views/person/html/signup.php
+++ b/src/components/com_people/views/person/html/signup.php
@@ -23,7 +23,7 @@
 			class="well"
 			autocomplete="off"
 		>
-            <input type="hidden" name="action" value="add" />
+            
             <fieldset>
                 <legend>
                     <?= @text('COM-PEOPLE-ACTION-CREATE-AN-ACCOUNT') ?>


### PR DESCRIPTION
With action=add on this form, when a user signs up, it bypasses ComPeopleControllerPerson::_actionPost (https://github.com/anahitasocial/anahita/blob/master/src/components/com_people/controllers/person.php#L119) and onBeforeSavePerson never fires when a new user signs up. Necessary to check captcha on registration so spam accounts aren't saved.