### PR TITLE
Add configurable send limit for notification cron

### DIFF
--- a/src/components/com_notifications/config.json
+++ b/src/components/com_notifications/config.json
@@ -15,6 +15,12 @@
             "name": "use_cron",
             "label": "Use Cron",
             "default": 0
+        },
+        {
+            "type": "text",
+            "name": "send_limit",
+            "label": "Send Limit",
+            "default": ""
         }
     ]
 }

--- a/src/components/com_notifications/controllers/processor.php
+++ b/src/components/com_notifications/controllers/processor.php
@@ -64,10 +64,19 @@ class ComNotificationsControllerProcessor extends ComBaseControllerResource
                       ->getQuery(true)
                       ->status(ComNotificationsDomainEntityNotification::STATUS_NOT_SENT);
 
+        $limit = get_config_value('notifications.send_limit');
+
+        if($limit) {
+            $query->limit($limit);
+            $query->order('creationTime', 'ASC');
+        }
+
         if ($this->id) {
             $ids = (array) KConfig::unbox($this->id);
             $query->id($ids);
         }
+
+        print_query($query);
 
         $notifications = $query->fetchSet();
 

--- a/src/components/com_notifications/controllers/processor.php
+++ b/src/components/com_notifications/controllers/processor.php
@@ -76,8 +76,6 @@ class ComNotificationsControllerProcessor extends ComBaseControllerResource
             $query->id($ids);
         }
 
-        print_query($query);
-
         $notifications = $query->fetchSet();
 
         $this->sendNotifications($notifications);


### PR DESCRIPTION
Adds a config option to com_notifications to set a limit on how many notifications are sent each time the process is run. Orders by creation time so the oldest notifications get sent first. Should help prevent the cron from timing out.