### PR TITLE
make magic get & set methods public

### DIFF
--- a/src/components/com_settings/setting.php
+++ b/src/components/com_settings/setting.php
@@ -124,7 +124,7 @@
          return $default;
      }
 
-     protected function __get($key)
+     public function __get($key)
      {
          if ($key === 'template' && !is_dir(ANPATH_THEMES.DS.$this->get($key))) {
              return $this->_default_template;
@@ -154,7 +154,7 @@
          return $this->_settings->$key;
      }
 
-     protected function __set($key, $value)
+     public function __set($key, $value)
      {
          return $this->set($key, $value);
      }


### PR DESCRIPTION
while debugging the login issue, I've been getting exceptions cause these methods need to be public and not private. Doesn't seem to be causing the login issue, but thought it was worth fixing.