### PR TITLE
remove extra meta

### DIFF
--- a/src/components/com_settings/templates/helpers/ui.php
+++ b/src/components/com_settings/templates/helpers/ui.php
@@ -262,8 +262,6 @@ class ComSettingsTemplateHelperUi extends ComBaseTemplateHelperUi
           'class' => 'input-block-level'
         ));
 
-        $config->name = 'meta['.$config->name.']';
-
         return $this->_render('formfield_custom', $config);
     }
 


### PR DESCRIPTION
with this extra line in here, the actual name of the custom input for photos is meta[meta[photoupload]]. As such, when the settings for the photo app is changed, it's not saved to the database. Removed it from the formfield_custom function to keep the _renderForm function consistent.