### PR TITLE
only get session if enabled

### DIFF
--- a/src/components/com_application/controllers/behaviors/message.php
+++ b/src/components/com_application/controllers/behaviors/message.php
@@ -32,15 +32,13 @@ class ComApplicationControllerBehaviorMessage extends AnControllerBehaviorAbstra
 
         $this->_enabled = $config->enabled;
         $namespace = $this->_getQueueNamespace(false);
-
-        $session = AnService::get('com:sessions', array(
-                        'namespace' => $namespace->namespace,
-                        'storage' => (PHP_SAPI == 'cli') ? 'none' : 'database'
-                    ));
-
         $data = array();
 
         if ($this->_enabled) {
+            $session = AnService::get('com:sessions', array(
+                        'namespace' => $namespace->namespace,
+                        'storage' => (PHP_SAPI == 'cli') ? 'none' : 'database'
+                    ));
             $data = (array) $session->set($namespace->queue, new stdClass(), $namespace->namespace);
         }
 


### PR DESCRIPTION
This is causing some issues with some cli work I've been doing. Because the session is being fetched, it's calling session start and sending headers when they aren't needed. This check just prevents it from being fetched unless it's really being used.