### PR TITLE
entity after.add

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 To view the detailed commits log go to https://github.com/anahitasocial/anahita/commits/master
 
+Anahita 4.6.2
+=============================
+- fixed: issue with entity not being persisted when behaviours' after.add methods are called. This was resulting into hashtags and mentions not being added when creating an entity.
+
 Anahita 4.6.1
 =============================
 - added: missing translations for the medium node views article, topic, todo, photo

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Anahita
 
-*Version:* 4.6.1 Birth Release
+*Version:* 4.6.2 Embryo Release
 
 Anahita is a platform and framework for developing open science and knowledge-sharing applications on a social networking foundation. Use Anahita to build:
 

--- a/src/components/com_hashtags/domains/behaviors/hashtaggable.php
+++ b/src/components/com_hashtags/domains/behaviors/hashtaggable.php
@@ -51,11 +51,15 @@
         if (!is_string($term)) {
             return;
         }
+        
+        $hashtag = $this->getService('repos:hashtags.hashtag')
+                        ->findOrAddNew(array('name' => $term));
 
-        if ($hashtag = $this->getService('repos:hashtags.hashtag')->findOrAddNew(array('name' => $term))) {
-            $this->hashtags->insert($hashtag);
-
-            return $this;
+        if ($hashtag) {
+            if (! $this->hashtags->find($hashtag)) {
+                $this->hashtags->insert($hashtag);
+                return $this;
+            }
         }
 
         return;
@@ -75,11 +79,15 @@
             return;
         }
 
-        if ($hashtag = $this->getService('repos:hashtags.hashtag')->find(array('name' => $term))) {
+        $hashtag = $this->getService('repos:hashtags.hashtag')
+                        ->find(array('name' => $term));
+
+        if ($hashtag) {
             $this->hashtags->extract($hashtag);
+            return $this;
         }
 
-        return $this;
+        return;
     }
 
     /**
@@ -93,7 +101,6 @@
     public function getHashtags()
     {
         $this->get('hashtags')->getQuery()->select('name');
-
         return $this->get('hashtags');
     }
  }

--- a/src/libraries/anahita/anahita.php
+++ b/src/libraries/anahita/anahita.php
@@ -21,7 +21,7 @@ class anahita
      *
      * @var string
      */
-    protected static $_version = '4.6.1';
+    protected static $_version = '4.6.2';
 
     /**
      * Path to Anahita libraries.

--- a/src/libraries/anahita/controller/behavior/abstract.php
+++ b/src/libraries/anahita/controller/behavior/abstract.php
@@ -34,7 +34,7 @@ abstract class AnControllerBehaviorAbstract extends AnBehaviorAbstract
 
 		$parts = explode('.', $name);
 		
-		if ($parts[0] == 'action') {
+		if ($parts[0] === 'action') {
 		    $method = '_action'.ucfirst($parts[1]);
 
 		    if (method_exists($this, $method)) {

--- a/src/libraries/default/base/controller/behavior/serviceable.php
+++ b/src/libraries/default/base/controller/behavior/serviceable.php
@@ -173,7 +173,15 @@ class LibBaseControllerBehaviorServiceable extends AnControllerBehaviorAbstract
     {
         $context->response->status = AnHttpResponse::CREATED;
         $entity = $this->getRepository()->getEntity()->setData($context['data']);
-        
+
+        /*
+        *   Ideally the commit should do all the required saving, but
+        *   for after.add behaviour methods to work, we need the entity
+        *   to have an persisted and have an id. Until we have a cleaner
+        *   approach, we are going to call the save method here.
+        */
+        $entity->save();
+
         $this->setItem($entity);
 
         return $this->getItem();


### PR DESCRIPTION
- fixed: issue with entity not being persisted when behaviours' after.add methods are called. This was resulting into hashtags and mentions not being added when creating an entity.